### PR TITLE
feat(blog): filter issues with meta labels from the home feed

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -34,6 +34,13 @@ NEXT_PUBLIC_GITHUB_REPO=dica-dev
 # repos. Create at https://github.com/settings/tokens
 GITHUB_TOKEN=
 
+# (Optional) Comma-separated extra GitHub issue labels to HIDE from
+# the blog (always-on default: meta, _meta, internal, _internal, admin).
+# Use this to suppress tracking/project issues (e.g. 'chore,tracking').
+# Case-insensitive. Add a label to the issue on GitHub, then list it
+# here and the post disappears from the home and related lists.
+GITHUB_EXCLUDE_LABELS=
+
 
 # ── App runtime: SEO (read by src/lib/site.ts) ──────────────────
 

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,5 +1,7 @@
 import 'server-only'
 
+import { isExcludedByLabel } from './site'
+
 const GITHUB_API_BASE = 'https://api.github.com'
 
 const GITHUB_USER = process.env.NEXT_PUBLIC_GITHUB_USER || 'brennoclins'
@@ -148,11 +150,15 @@ export async function getGithubIssuesPage(
     `/search/issues?q=${q}&page=${page}&per_page=${perPage}&sort=updated&order=desc`
   )
 
+  const visibleItems = data.items.filter(
+    issue => !isExcludedByLabel(issue.labels)
+  )
+
   const hasMore =
     data.items.length === perPage && data.total_count > page * perPage
 
   return {
-    items: data.items,
+    items: visibleItems,
     total_count: data.total_count,
     hasMore,
   }
@@ -231,6 +237,7 @@ export async function getRelatedIssues(
     .filter(
       issue =>
         issue.number !== currentNumber &&
+        !isExcludedByLabel(issue.labels) &&
         issue.labels.some(l => labelSet.has(l.name))
     )
     .slice(0, limit)

--- a/src/lib/site.test.ts
+++ b/src/lib/site.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { EXCLUDE_LABELS, isExcludedByLabel } from './site'
+
+describe('isExcludedByLabel', () => {
+  it('excludes issues with default meta labels', () => {
+    expect(isExcludedByLabel([{ name: 'meta' }])).toBe(true)
+    expect(isExcludedByLabel([{ name: 'internal' }])).toBe(true)
+    expect(isExcludedByLabel([{ name: '_meta' }])).toBe(true)
+    expect(isExcludedByLabel([{ name: '_internal' }])).toBe(true)
+    expect(isExcludedByLabel([{ name: 'admin' }])).toBe(true)
+  })
+
+  it('is case-insensitive', () => {
+    expect(isExcludedByLabel([{ name: 'META' }])).toBe(true)
+    expect(isExcludedByLabel([{ name: 'Internal' }])).toBe(true)
+  })
+
+  it('does not exclude issues with non-meta labels', () => {
+    expect(isExcludedByLabel([{ name: 'bug' }])).toBe(false)
+    expect(isExcludedByLabel([{ name: 'enhancement' }])).toBe(false)
+    expect(isExcludedByLabel([])).toBe(false)
+  })
+
+  it('excludes if ANY label is in the meta list', () => {
+    expect(
+      isExcludedByLabel([{ name: 'bug' }, { name: 'meta' }, { name: 'help' }])
+    ).toBe(true)
+  })
+
+  it('ships with sane defaults', () => {
+    expect(EXCLUDE_LABELS).toContain('meta')
+    expect(EXCLUDE_LABELS).toContain('internal')
+    expect(EXCLUDE_LABELS.length).toBeGreaterThanOrEqual(5)
+  })
+})

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -10,3 +10,25 @@ export const SITE_CONFIG = {
 
 export const SITE_URL =
   process.env.NEXT_PUBLIC_SITE_URL ?? 'https://dica-dev.vercel.app'
+
+const DEFAULT_META_LABELS = ['meta', '_meta', 'internal', '_internal', 'admin']
+
+function parseExcludeLabels(raw: string | undefined): string[] {
+  if (!raw) return DEFAULT_META_LABELS
+  const custom = raw
+    .split(',')
+    .map(label => label.trim().toLowerCase())
+    .filter(Boolean)
+  return Array.from(new Set([...DEFAULT_META_LABELS, ...custom]))
+}
+
+export const EXCLUDE_LABELS: readonly string[] = parseExcludeLabels(
+  process.env.GITHUB_EXCLUDE_LABELS
+)
+
+export function isExcludedByLabel(
+  labels: ReadonlyArray<{ name: string }>
+): boolean {
+  const labelSet = new Set(EXCLUDE_LABELS)
+  return labels.some(label => labelSet.has(label.name.toLowerCase()))
+}


### PR DESCRIPTION
The blog currently pulls every issue from the GitHub repo and renders it as a post. The 'Feat/modernization v2' tracking issue (#83) is about the project itself, not a content post, so it has no business showing up on the home page next to 'Removendo Kernels antigos no Fedora 44' and other real tips.

This adds a configurable exclusion filter based on issue labels.

Changes
=======

src/lib/site.ts
- DEFAULT_META_LABELS = ['meta', '_meta', 'internal', '_internal', 'admin']
- parseExcludeLabels(raw) reads GITHUB_EXCLUDE_LABELS env var (comma-separated) and merges with the defaults; lowercased, deduped.
- EXCLUDE_LABELS: readonly string[] exported for the filter logic and for tests.
- isExcludedByLabel(labels) returns true if ANY label on the issue matches one in EXCLUDE_LABELS. Case-insensitive.

src/lib/github.ts
- getGithubIssuesPage now filters out excluded issues before returning. total_count still reflects the raw GitHub search total (we don't try to second-guess how many hidden issues are on later pages); hasMore is still based on the raw response.
- getRelatedIssues also skips excluded issues, so a /post page won't show the meta issue as a 'related post'.

src/lib/site.test.ts (new, 5 tests)
- Excludes each default meta label
- Case-insensitive
- Does NOT exclude non-meta labels
- Excludes if ANY label matches
- Ships with sane defaults

.env.local.example
- Documents the new GITHUB_EXCLUDE_LABELS env var.

How to hide an existing issue
=============================
1. Open the issue on GitHub
2. Add a 'meta' label (or any of the defaults), or add a custom label and append it to GITHUB_EXCLUDE_LABELS
3. Redeploy

The 'Feat/modernization v2' issue already exists in the repo but has no 'meta' label yet; the maintainer should add the label to trigger the filter. No code change required on the project side beyond this commit.

Tests: 40/40 passing (was 35/35, +5 for site.test.ts)
Typecheck: clean
Biome: clean