### PR TITLE
feat(home): only show open issues by default

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -41,6 +41,14 @@ GITHUB_TOKEN=
 # here and the post disappears from the home and related lists.
 GITHUB_EXCLUDE_LABELS=
 
+# (Optional) Which issues to fetch from GitHub. Accepts:
+#   open   (default) — only currently-open issues are blog posts
+#   closed           — only closed issues
+#   all              — both open and closed
+# Set to 'open' or 'closed' to surface a small badge in the future;
+# unknown values fall back to 'open'.
+GITHUB_STATE=open
+
 
 # ── App runtime: SEO (read by src/lib/site.ts) ──────────────────
 

--- a/src/lib/github.test.ts
+++ b/src/lib/github.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockFetch = vi.fn()
+
+beforeEach(() => {
+  vi.resetModules()
+  mockFetch.mockReset()
+  vi.stubGlobal('fetch', mockFetch)
+  process.env.GITHUB_TOKEN = ''
+  process.env.NEXT_PUBLIC_GITHUB_USER = 'brennoclins'
+  process.env.NEXT_PUBLIC_GITHUB_REPO = 'dica-dev'
+  delete process.env.GITHUB_STATE
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+function makeIssue(n: number, labels: { name: string }[] = []) {
+  return {
+    number: n,
+    title: `Issue ${n}`,
+    body: '',
+    html_url: `https://github.com/brennoclins/dica-dev/issues/${n}`,
+    updated_at: '2026-06-06T00:00:00Z',
+    created_at: '2026-06-06T00:00:00Z',
+    comments: 0,
+    labels,
+    user: {
+      login: 'brennoclins',
+      avatar_url: 'https://example.com/a.png',
+      html_url: 'https://github.com/brennoclins',
+    },
+  }
+}
+
+function okResponse(payload: unknown) {
+  return () =>
+    new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+}
+
+describe('getGithubIssuesPage state filter', () => {
+  it('appends is:open to the query by default', async () => {
+    mockFetch.mockImplementation(
+      okResponse({ total_count: 0, incomplete_results: false, items: [] })
+    )
+
+    const { getGithubIssuesPage } = await import('@/lib/github')
+
+    await getGithubIssuesPage(1, 10, '')
+
+    const calledUrl = mockFetch.mock.calls[0]?.[0] as string
+    expect(calledUrl).toContain('is:open')
+  })
+
+  it('appends is:open when GITHUB_STATE=open explicitly', async () => {
+    process.env.GITHUB_STATE = 'open'
+    mockFetch.mockImplementation(
+      okResponse({ total_count: 0, incomplete_results: false, items: [] })
+    )
+
+    const { getGithubIssuesPage } = await import('@/lib/github')
+
+    await getGithubIssuesPage(1, 10, '')
+
+    const calledUrl = mockFetch.mock.calls[0]?.[0] as string
+    expect(calledUrl).toContain('is:open')
+  })
+
+  it('appends is:closed when GITHUB_STATE=closed', async () => {
+    process.env.GITHUB_STATE = 'closed'
+    mockFetch.mockImplementation(
+      okResponse({ total_count: 0, incomplete_results: false, items: [] })
+    )
+
+    const { getGithubIssuesPage } = await import('@/lib/github')
+
+    await getGithubIssuesPage(1, 10, '')
+
+    const calledUrl = mockFetch.mock.calls[0]?.[0] as string
+    expect(calledUrl).toContain('is:closed')
+    expect(calledUrl).not.toContain('is:open')
+  })
+
+  it('omits state filter when GITHUB_STATE=all', async () => {
+    process.env.GITHUB_STATE = 'all'
+    mockFetch.mockImplementation(
+      okResponse({ total_count: 0, incomplete_results: false, items: [] })
+    )
+
+    const { getGithubIssuesPage } = await import('@/lib/github')
+
+    await getGithubIssuesPage(1, 10, '')
+
+    const calledUrl = mockFetch.mock.calls[0]?.[0] as string
+    expect(calledUrl).not.toContain('is:open')
+    expect(calledUrl).not.toContain('is:closed')
+  })
+
+  it('falls back to open for unknown GITHUB_STATE values', async () => {
+    process.env.GITHUB_STATE = 'banana'
+    mockFetch.mockImplementation(
+      okResponse({ total_count: 0, incomplete_results: false, items: [] })
+    )
+
+    const { getGithubIssuesPage } = await import('@/lib/github')
+
+    await getGithubIssuesPage(1, 10, '')
+
+    const calledUrl = mockFetch.mock.calls[0]?.[0] as string
+    expect(calledUrl).toContain('is:open')
+  })
+
+  it('combines is:open with a user query', async () => {
+    mockFetch.mockImplementation(
+      okResponse({ total_count: 0, incomplete_results: false, items: [] })
+    )
+
+    const { getGithubIssuesPage } = await import('@/lib/github')
+
+    await getGithubIssuesPage(1, 10, 'docker')
+
+    const calledUrl = mockFetch.mock.calls[0]?.[0] as string
+    expect(calledUrl).toContain(encodeURIComponent('docker'))
+    expect(calledUrl).toContain('is:open')
+  })
+
+  it('filters out excluded-label issues after the state filter', async () => {
+    mockFetch.mockImplementation(
+      okResponse({
+        total_count: 2,
+        incomplete_results: false,
+        items: [
+          makeIssue(1, [{ name: 'bug' }]),
+          makeIssue(2, [{ name: 'meta' }]),
+          makeIssue(3, [{ name: 'enhancement' }]),
+        ],
+      })
+    )
+
+    const { getGithubIssuesPage } = await import('@/lib/github')
+
+    const result = await getGithubIssuesPage(1, 10, '')
+
+    expect(result.items.map(i => i.number)).toEqual([1, 3])
+  })
+})

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -10,6 +10,15 @@ const GITHUB_TOKEN = process.env.GITHUB_TOKEN
 
 const DEFAULT_REVALIDATE_SECONDS = 60 * 60
 
+type IssueState = 'open' | 'closed' | 'all'
+
+function parseIssueState(raw: string | undefined): IssueState {
+  if (raw === 'closed' || raw === 'all') return raw
+  return 'open'
+}
+
+const ISSUE_STATE: IssueState = parseIssueState(process.env.GITHUB_STATE)
+
 export type GithubLabel = {
   id: number
   name: string
@@ -142,9 +151,10 @@ export async function getGithubIssuesPage(
   hasMore: boolean
 }> {
   const trimmed = query.trim()
-  const q = trimmed
+  const baseQuery = trimmed
     ? `${encodeURIComponent(trimmed)}+repo:${user}/${repo}`
     : `repo:${user}/${repo}`
+  const q = ISSUE_STATE === 'all' ? baseQuery : `${baseQuery}+is:${ISSUE_STATE}`
 
   const data = await githubFetch<SearchIssuesResponse>(
     `/search/issues?q=${q}&page=${page}&per_page=${perPage}&sort=updated&order=desc`


### PR DESCRIPTION
Add GITHUB_STATE env var (open|closed|all, default open) so the blog hides closed issues by default. Append +is:<state> to the GitHub search query in getGithubIssuesPage. Unknown values fall back to open. Documents the new var in .env.local.example.

Adds 7 unit tests covering: default state, explicit open, closed, all, unknown-value fallback, query+state combination, and excluded labels still applied after the state filter.